### PR TITLE
Fix test runners in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lib": "lib"
   },
   "scripts": {
-    "copy": "rm -rf lib/ && cp -r src/ lib/",
+    "copy": "rm -rf lib/ && mkdir lib && cp -r src/ lib/",
     "babel": "babel src/ --out-dir lib --presets babel-preset-es2015,babel-preset-stage-0",
     "babel:watch": "babel src/ --watch --out-dir lib --presets babel-preset-es2015,babel-preset-stage-0",
     "mocha": "mocha test/  --reporter spec --compilers js:babel-core/register",


### PR DESCRIPTION
On my current machine, the "npm test" command fails due to the copy script, which is caused by cp trying to copy to a non-existent directory (lib/), which has been deleted by the previous "rm -rf lib/" command. A simple mkdir would've resolved this.